### PR TITLE
[ISSUE-3] 슬랙 메시지 발송 시 커스텀 카테고리 채널 지원 기능 추가

### DIFF
--- a/domain/mbus.go
+++ b/domain/mbus.go
@@ -41,8 +41,9 @@ const (
 )
 
 const (
-	NotifyAlarm          = "ALARM"
-	ActionProcessStartup = "PROCESS_STARTUP"
+	NotifyAlarm           = "ALARM"
+	ActionProcessStartup  = "PROCESS_STARTUP"
+	ActionProcessShutdown = "PROCESS_SHUTDOWN"
 )
 
 type MessageNotify interface {
@@ -118,6 +119,14 @@ func (m MBusMessageBody) IsProcessStartup() bool {
 		return true
 	}
 	return false
+}
+
+func (m MBusMessageBody) IsProcessShutdown() bool {
+	return ActionProcessShutdown == m.Message[MessageKeyAction]
+}
+
+func (m MBusMessageBody) IsProcessStartupOrShutdown() bool {
+	return m.IsProcessStartup() || m.IsProcessShutdown()
 }
 
 func (m MBusMessageBody) GetCategory() string {

--- a/notifier/slack/slack.go
+++ b/notifier/slack/slack.go
@@ -45,6 +45,8 @@ const (
 	footerIcon               = "https://platform.slack-edge.com/img/default_application_icon.png"
 	applicationJsonUtf8Value = "application/json;charset=UTF-8"
 	PropertyFmonUrl          = "fmon.url"
+
+	deployCategory = "deploy"
 )
 
 func NewSlackNotification(fatimaRuntime fatima.FatimaRuntime) *SlackNotification {
@@ -80,8 +82,9 @@ type SlackNotification struct {
 }
 
 type SlackConfig struct {
-	Active bool
-	Url    string
+	Active  bool
+	Url     string
+	Channel string
 }
 
 func (s *SlackNotification) GetFmonUrl() string {
@@ -91,7 +94,11 @@ func (s *SlackNotification) GetFmonUrl() string {
 func (s *SlackNotification) SendNotify(mbus domain.MBusMessageBody) {
 	message := s.buildSlackMessage(mbus)
 	cate := mbus.GetCategory()
+
 	if mbus.IsAlarm() {
+		if mbus.IsProcessStartupOrShutdown() && len(cate) == 0 {
+			cate = deployCategory
+		}
 		s.sendAlarm(message, cate)
 	} else {
 		s.sendEvent(message)
@@ -191,19 +198,17 @@ func (s *SlackNotification) isAlarmCategoryWritable(cate string) bool {
 	return true
 }
 
-func (s *SlackNotification) getAlarmCategoryUrl(cate string) string {
-	url := ""
+func (s *SlackNotification) getAlarmCategoryUrlAndChannel(cate string) (url string, channel string) {
 	if len(cate) == 0 {
-		return url
+		return
 	}
 
 	config, ok := s.alarmCategory[cate]
 	if !ok {
-		return url
+		return
 	}
 
-	url = config.Url
-	return url
+	return config.Url, config.Channel
 }
 
 func (s *SlackNotification) sendEvent(m map[string]interface{}) {
@@ -233,8 +238,13 @@ func (s *SlackNotification) sendAlarm(m map[string]interface{}, cate string) {
 		return
 	}
 
-	url := s.getAlarmCategoryUrl(cate)
+	url, channel := s.getAlarmCategoryUrlAndChannel(cate)
+
 	if len(url) > 0 {
+		if len(channel) > 0 {
+			m["channel"] = channel
+		}
+
 		b, err := json.Marshal(m)
 		if err != nil {
 			log.Warn("fail to build json : %s", err.Error())


### PR DESCRIPTION
[프로세스 배포 관련 알림은 별도 채널로 전달](https://github.com/fatima-go/saturn/issues/3) 이슈 대응을 위한 리뷰 요청입니다.

ProcessStartup, Shutdown 을 전달 받을 시 cate 정보가 없다면 deploy 로 변경 후 정의된 webhook uri 를 통해 메시지를 전달토록 수정했습니다.

또한 webhook uri 는 연결된 기본 채널로 항상 메시지가 전달 되기 때문에 해당 uri 이외에 다른 채널로도 받아볼 수 있도록 채널 지원 기능도 추가하였으니 참고해 주세요.